### PR TITLE
Force redirect and prevent the requested action from being executed

### DIFF
--- a/app/code/community/Divante/VueStorefrontExternalCheckout/Model/Observer.php
+++ b/app/code/community/Divante/VueStorefrontExternalCheckout/Model/Observer.php
@@ -44,7 +44,6 @@ class Divante_VueStorefrontExternalCheckout_Model_Observer
         $path = $route.DS.$controller.DS.$action;
 
         $exclude_routes = preg_split('/\r\n|[\r\n]/', Mage::getStoreConfig(SELF::EXCLUDE_ROUTE,Mage::app()->getStore()));
-        $vsf_url = Mage::getStoreConfig(SELF::VUESTOREFRONT_URL,Mage::app()->getStore());
 
         if(!Mage::getStoreConfig( SELF::REDIRECT_ALL,Mage::app()->getStore() )){
             return $this;
@@ -59,7 +58,12 @@ class Divante_VueStorefrontExternalCheckout_Model_Observer
                 }
             }
 
-            Mage::app()->getFrontController()->getResponse()->setRedirect($vsf_url);
+            // Force an interruption of the controller dispatching,
+            // to prevent the requested action from being executed.
+            // If only a redirect is defined, the action will still be executed.
+            $exception = new Mage_Core_Controller_Varien_Exception();
+            $exception->prepareForward('redirect', 'redirect', 'vue');
+            throw $exception;
         }
 
     }

--- a/app/code/community/Divante/VueStorefrontExternalCheckout/controllers/RedirectController.php
+++ b/app/code/community/Divante/VueStorefrontExternalCheckout/controllers/RedirectController.php
@@ -1,0 +1,15 @@
+<?php
+
+class Divante_VueStorefrontExternalCheckout_RedirectController extends Mage_Core_Controller_Front_Action
+{
+    /**
+     * Redirect to the vue storefront url.
+     */
+    public function redirectAction()
+    {
+        $configPath = Divante_VueStorefrontExternalCheckout_Model_Observer::VUESTOREFRONT_URL;
+        $vsf_url = Mage::getStoreConfig($configPath, Mage::app()->getStore());
+
+        $this->_redirectUrl($vsf_url);
+    }
+}


### PR DESCRIPTION
This PR solves #7 by throwing a `Mage_Core_Controller_Varien_Exception` in the observer's `preDispatch` method. This way the requested action is not executed anymore by Magento.

The background is that in the mentioned action the status code could be overwritten (e.g. in th noroute action), which makes the redirect useless.